### PR TITLE
SWIFT-1127 BSONDocument should conform to Content protocol

### DIFF
--- a/Sources/MongoDBVapor/MongoDB+Content.swift
+++ b/Sources/MongoDBVapor/MongoDB+Content.swift
@@ -22,3 +22,7 @@ extension ExtendedJSONDecoder: ContentDecoder {
         try self.decode(D.self, from: body)
     }
 }
+
+/// Enables `BSONDocument` to be used as a `Content` type when `ExtendedJSONEncoder`/`ExtendedJSONDecoder` are set as
+/// the default JSON encoder/decoder for the application.
+extension BSONDocument: Content {}


### PR DESCRIPTION
Makes `BSONDocument` conform to `Content` and adds some tests around working with `BSONDocument` in routes.