### PR TITLE
SWIFT-1125 Add release script

### DIFF
--- a/etc/release.sh
+++ b/etc/release.sh
@@ -37,4 +37,5 @@ git tag "v${version}"
 git push --tags
 
 # go to GitHub to publish release notes
-open "https://github.com/mongodb/mongodb-vapor/releases/tag/v${version}"
+echo "Successfully tagged release! \
+Go here to publish release notes: https://github.com/mongodb/mongodb-vapor/releases/tag/v${version}"

--- a/etc/release.sh
+++ b/etc/release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# usage: ./etc/release.sh [new version string]
+
+# exit if any command fails
+set -e
+
+# ensure we are on main before releasing
+git checkout main
+
+version=${1}
+# Ensure version is non-empty
+[ ! -z "${version}" ] || { echo "ERROR: Missing version string"; exit 1; }
+
+# regenerate documentation with new version string
+./etc/generate-docs.sh ${version}
+
+# switch to docs branch to commit and push
+git checkout gh-pages
+
+rm -rf docs/current
+cp -r docs-temp docs/current
+mv docs-temp docs/${version}
+
+# build up documentation index
+python3 ./_scripts/update-index.py
+
+git add docs/
+git commit -m "${version} docs"
+git push
+
+# go back to wherever we started
+git checkout -
+
+# tag release and push tag
+git tag "v${version}"
+git push --tags
+
+# go to GitHub to publish release notes
+open "https://github.com/mongodb/mongodb-vapor/releases/tag/v${version}"


### PR DESCRIPTION
Adds a release script for the library. This is extremely similar to our other release scripts, so hopefully easy to review 🙂

I tested this out with the lines that actually tag a release commented out to ensure the docs logic worked correctly. You can see resulting docs now for two (not actually tagged) versions here: https://mongodb.github.io/mongodb-vapor/

I figure I will just delete the directories for those once before we actually release this.