### PR TITLE
SWIFT-1215 Add docstrings to Vapor type extensions

### DIFF
--- a/Sources/MongoDBVapor/MongoDBVapor.swift
+++ b/Sources/MongoDBVapor/MongoDBVapor.swift
@@ -6,7 +6,8 @@ import Vapor
  * MongoDB deployment. All of the API is namespaced under the `.mongoDB` property on the `Application.MongoDB` type.
  * This extension supports the following:
  *
- * - Configuring a global MongoDB client for your application via `Application.MongoDB.configure(_:options:)`, for example:
+ * - Configuring a global MongoDB client for your application via `Application.MongoDB.configure(_:options:)`, for
+ *   example:
  * ```
  * myApp.mongoDB.configure("mongodb://localhost:27017")
  * ```
@@ -16,7 +17,8 @@ import Vapor
  * myApp.mongoDB.client.listDatabases()
  * ```
  *
- * - Cleaning up the global client when your application is shutting down via `Application.MongoDB.cleanup()`, for example:
+ * - Cleaning up the global client when your application is shutting down via `Application.MongoDB.cleanup()`,
+ *   for example:
  * ```
  * myApp.mongDB.cleanup()
  * ```
@@ -111,7 +113,7 @@ public extension Application {
             }
         }
     }
-} 
+}
 
 /**
  * An extension to Vapor's `Request` type to add support for conveniently accessing MongoDB core types e.g.

--- a/Sources/MongoDBVapor/MongoDBVapor.swift
+++ b/Sources/MongoDBVapor/MongoDBVapor.swift
@@ -131,7 +131,7 @@ extension Application {
  * extension Request {
  *     /// A collection with an associated `Codable` type `Kitten`.
  *     var kittenCollection: MongoCollection<Kitten> {
- *         self.client.db("home").collection("kittens", withType: Kitten.self)
+ *         self.mongoDB.client.db("home").collection("kittens", withType: Kitten.self)
  *     }
  * }
  * ```

--- a/Sources/MongoDBVapor/MongoDBVapor.swift
+++ b/Sources/MongoDBVapor/MongoDBVapor.swift
@@ -25,14 +25,14 @@ import Vapor
  *
  * See `Application.MongoDB` for further details.
  */
-public extension Application {
+extension Application {
     /// Returns an instance of `MongoDB`, providing access to MongoDB APIs for use at the `Application` level.
-    var mongoDB: MongoDB {
+    public var mongoDB: MongoDB {
         MongoDB(application: self)
     }
 
     /// A type providing access to MongoDB APIs for use at the `Application` level.
-    struct MongoDB {
+    public struct MongoDB {
         private struct MongoClientKey: StorageKey {
             typealias Value = MongoClient
         }
@@ -136,14 +136,14 @@ public extension Application {
  * }
  * ```
  */
-public extension Request {
+extension Request {
     /// Returns an instance of `MongoDB`, providing access to MongoDB APIs for use at the `Request` level.
-    var mongoDB: MongoDB {
+    public var mongoDB: MongoDB {
         MongoDB(request: self)
     }
 
     /// A type providing access to MongoDB APIs for use at the `Request` level.
-    struct MongoDB {
+    public struct MongoDB {
         internal let request: Request
 
         internal init(request: Request) {


### PR DESCRIPTION
Adds documentation to our Vapor extension types. These don't currently show up due to the Jazzy issue, but i did check that they render correctly by putting them on some temporary fake types and generating the docs.

~For the sake of getting the release out before https://github.com/vapor/vapor/pull/2626 is merged/released, I will probably just manually paste in the HTML for these to the generated docs.~ Was just merged and released, so all good there 🙂

Also, I looked into having some documentation on the top-level "Vapor Extensions" page but Jazzy does not seem to support that.