### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ To summarize the available features:
 
 ### Configure global settings
 
+In your `configure(_:)` method in `App/configure.swift`, add:
+```swift
+// Configure the app for using a MongoDB server at the provided connection string.
+try app.mongoDB.configure("mongodb://localhost:27017")
+```
+
 In `Run/main.swift`, add:
 ```swift
 import MongoDBVapor
-
-// Configure the app for using a MongoDB server at the provided connection string.
-try app.mongoDB.configure("mongodb://localhost:27017")
 
 defer {
     // Cleanup the application's MongoDB data.


### PR DESCRIPTION
As mentioned in mongodb/mongodb-vapor-template#4, it's recommended to put DB configuration logic in the `configure(_:)` method.
It's not ideal that logic is also needed in `main.swift`, but hopefully in the long-term we can get rid of the need for explicit cleanup anyway