### PR TITLE
Update to mongo-swift-driver 1.3.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
-        .package(url: "https://github.com/mongodb/mongo-swift-driver", .exact("1.3.0-beta.1")),
+        .package(url: "https://github.com/mongodb/mongo-swift-driver", .upToNextMajor(from: "1.3.1")),
         .package(url: "https://github.com/vapor/vapor", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [


### PR DESCRIPTION
I am not sure if `upToNextMajor` is okay to use here or if it's still better to pin to an exact version, but please let me know 🙏 