### PR TITLE
Update ContentEncoder/ContentDecoder support

### DIFF
--- a/Sources/MongoDBVapor/MongoDB+Content.swift
+++ b/Sources/MongoDBVapor/MongoDB+Content.swift
@@ -1,25 +1,52 @@
 import MongoSwift
 import Vapor
 
-// These extension enable users to encode/decode their Content types to/from JSON using `ExtendedJSONEncoder` and
+// These extensions enable users to encode/decode their Content types to/from JSON using `ExtendedJSONEncoder` and
 // `ExtendedJSONDecoder`. This is useful in cases where users are using one of our custom BSON types in their
 // structs which does not currently support encoding/decoding via `JSONEncoder`/`JSONDecoder`.
 
+// Note that in the case where additional userInfo is provided, a copy has to be made of the encoder/decoder and the
+// info added to that, both for thread safety and to prevent the additional info from accidentally persisting. If
+// the encoder/decoder has existing user info configured and one or more keys are set in both it and the user info
+// provided to the method, the latter's values take precedence. This support is necessary for using Vapor's
+// Validation module with these coders.
+
 extension ExtendedJSONEncoder: ContentEncoder {
-    public func encode<E>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders) throws
-        where E: Encodable
-    {
+    public func encode<E: Encodable>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders) throws {
+        try self.encode(encodable, to: &body, headers: &headers, userInfo: [:])
+    }
+
+    public func encode<E: Encodable>(_ encodable: E, to body: inout ByteBuffer, headers: inout HTTPHeaders, userInfo: [CodingUserInfoKey: Any]) throws {
+        let encoder: ExtendedJSONEncoder
+        if userInfo.isEmpty {
+            encoder = self
+        } else {
+            encoder = ExtendedJSONEncoder()
+            encoder.format = self.format
+            encoder.userInfo = self.userInfo.merging(userInfo, uniquingKeysWith: { $1 })
+        }
+
         headers.contentType = .json
-        var buffer = try self.encodeBuffer(encodable)
+        var buffer = try encoder.encodeBuffer(encodable)
         body.writeBuffer(&buffer)
     }
 }
 
 extension ExtendedJSONDecoder: ContentDecoder {
-    public func decode<D>(_: D.Type, from body: ByteBuffer, headers _: HTTPHeaders) throws -> D
-        where D: Decodable
-    {
-        try self.decode(D.self, from: body)
+    public func decode<D: Decodable>(_: D.Type, from body: ByteBuffer, headers: HTTPHeaders) throws -> D {
+        try self.decode(D.self, from: body, headers: headers, userInfo: [:])
+    }
+
+    public func decode<D: Decodable>(_: D.Type, from body: ByteBuffer, headers _: HTTPHeaders, userInfo: [CodingUserInfoKey: Any]) throws -> D {
+        let decoder: ExtendedJSONDecoder
+        if userInfo.isEmpty {
+            decoder = self
+        } else {
+            decoder = ExtendedJSONDecoder()
+            decoder.userInfo = self.userInfo.merging(userInfo, uniquingKeysWith: { $1 })
+        }
+
+        return try decoder.decode(D.self, from: body)
     }
 }
 


### PR DESCRIPTION
[Vapor 4.75.0](https://github.com/vapor/vapor/releases/tag/4.75.0) overhauled how the Validation module works. Unfortunately, in order to correct several issues with the old implementation without breaking API, the `ContentEncoder` and `ContentDecoder` protocols had to add new method requirements which allow specifying `userInfo` dictionaries on a per-encode/decode basis. While default implementations which invoke the legacy methods were provided for source compatibility, any custom coders conforming to these protocols no longer work when used for Validation (or with `ContentContainer`'s subscripts and `get()` methods) until they are updated accordingly.

In accordance with this concern (and since I'm the one who made the aforementioned changes and broke things 😅), I've provided the appropriate updates for `ExtendedJSONEncoder` and `ExtendedJSONDecoder`, and a simple test to ensure it now works.

(_Note: It is not necessary to require Vapor 4.75.0 in `Package.swift`; the new logic is purely additive and will have no impact if used with earlier versions._)